### PR TITLE
instructors: Add a Frequently Argued Issues section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,14 @@ You also agree to abide by our
     or have a look at [our actual lessons][swc-lessons].
     Comments on issues and reviews of pull requests are equally welcome.
 
+6.  If you want to submit a change that *doesn't* address an open
+    issue with this repository, please review our list of [frequently
+    argued issues][fai] (FAI) to avoid rehashing past discussions.  If
+    your change is not covered by an FAI entry, go ahead and submit
+    it.  If your change is covered by an FAI entry but the the reasons
+    for resolving the FAI seem incomplete, please submit a pull
+    request explaining why and adjusting the FAI entry.
+
 ## Other Resources
 
 1.  This lesson is based on the template found at
@@ -40,6 +48,7 @@ You also agree to abide by our
 2.  For a list of helpful commands run `make` in this directory.
 
 [conduct]: CONDUCT.md
+[fai]: instructors.md#frequently-argued-issues
 [issues]: https://github.com/swcarpentry/lesson-example/issues
 [lesson-template-issues]: https://github.com/swcarpentry/lesson-template/issues
 [license]: LICENSE.md

--- a/instructors.md
+++ b/instructors.md
@@ -23,3 +23,15 @@ subtitle: Instructor's Guide
 ## [Topic Title Two](02-two.html)
 
 *   Et cetera.
+
+## Frequently Argued Issues
+
+There have never been any FAIs with the approach taken by this
+repository!
+
+### Lesson template
+
+Difficult decisions about the [lesson template][lesson-template] are
+recorded in the [background and design document](DESIGN.md).
+
+[lesson-template]: https://github.com/swcarpentry/lesson-template


### PR DESCRIPTION
And link to it from CONTRIBUTING.md.

Background discussion in a number of places, most recently [here][1].
This patch follows [the example set by the novice Python lesson][2] in
a way that should require no edits by maintainers who don't need to
list any FAIs.

[1]: http://lists.software-carpentry.org/pipermail/maintainers_lists.software-carpentry.org/2016-January/000139.html
     Subject: Re: [Maintainers] Q: separate file for exercises + allowing trainees to submit diagrams
     Date: Fri, 29 Jan 2016 10:15:56 -0800
     Message-Id: <13F2D10E-4CAA-4FF1-8553-582753546DCA@gmail.com>
[2]: https://github.com/swcarpentry/python-novice-inflammation/blob/v5.3/instructors.md#frequently-argued-issues-fai