### PR TITLE
Update JavaScript locations to avoid errors

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,5 +7,5 @@
 <meta charset="UTF-8" />
 <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -1,3 +1,3 @@
 <!-- Javascript placed at the end of the document so the pages load faster -->
-<script src="http://software-carpentry.org/v5/js/jquery-1.9.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script src="css/bootstrap/bootstrap-js/bootstrap.js"></script>


### PR DESCRIPTION
The current jQuery file location produces a 404, and also a security warning in browsers now that GitHub Pages is using HTTPS by default (eg https://swcarpentry.github.io/python-novice-inflammation/).  In addition, because Bootstrap's JavaScript requires jQuery, a browser console errors currently occur on all pages.  The HTML5 shim will produce a security warning in IE as it is loaded from HTTP rather than HTTPS.

This PR uses Google's hosted jQuery API, which is free and uses HTTPS (plus as a bonus provides a global CDN for speed), and adjusts the HTML5 shim to use HTTPS, resolving all above issues.

The URL needs to be updated out in the Python and Shell lessons, and probably elsewhere, so what's the best way of having this cherry-picked?