### PR TITLE
README: Update 'r-gaia-cs' -> 'rgaiacs'

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ whenever you create a new lesson and would like to advertise it on our web site.
 
 *   Andy Boughton (@abought)
 *   Rémi Emonet (@twitwi)
-*   Raniere Silva (@r-gaia-cs)
+*   Raniere Silva (@rgaiacs)
 
 [swc-lesson-template]: https://github.com/swcarpentry/lesson-template
 [swc-lessons-page]: http://software-carpentry.org/lessons.html


### PR DESCRIPTION
I thought the hyphenated form was current when I used it in 0d8da61e
(README.md: Add local maintainer listing, 2015-04-15, #2), but GitHub
no longer recognizes the hyphenated form.  The un-hyphenated form
seems to [date back to 2012-03-06][1], so maybe I was just confused ;).
Anyhow, fixing to use the current username.

Ping @rgaiacs ;).

[1]: https://github.com/rgaiacs