### PR TITLE
Using a 'root' variable once again

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page_root
 title: "Contributor Code of Conduct"
 permalink: /conduct/
 ---

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page_root
 title: "Licenses"
 permalink: /license/
 ---

--- a/_episodes/02-tooling.md
+++ b/_episodes/02-tooling.md
@@ -34,7 +34,7 @@ in a template repo.
 The master copy of each lesson would be a fork of that repo,
 and each author's working copy would be a fork of that master:
 
-![Forking Repositories]({{ site.github.url }}/fig/forking.svg)
+![Forking Repositories]({{ page.root }}/fig/forking.svg)
 
 However, GitHub only allows a user to have one fork of any particular repo.
 This creates a problem for us because an author may be involved in writing several lessons,
@@ -44,7 +44,7 @@ After the lesson has been created,
 we manually add the [template repository]({{ site.template_repo }}) as a remote called `template`
 to update the lesson when the template changes.
 
-![Repository Links]({{ site.github.url }}/fig/repository-links.svg)
+![Repository Links]({{ page.root }}/fig/repository-links.svg)
 
 ## GitHub Pages
 
@@ -74,7 +74,7 @@ If authors want to write lessons in something else,
 such as [R Markdown][r-markdown],
 they must generate HTML or Markdown that [Jekyll][jekyll] can process
 and commit that to the repository.
-The [next episode]({{ site.github.url }}/02-formatting/) describes the Markdown we use.
+The [next episode]({{ page.root }}/02-formatting/) describes the Markdown we use.
 
 > ## Teaching Tools
 >
@@ -162,7 +162,7 @@ putting the extra files in `_extras` allows us to populate the "Extras" menu pul
 To clarify what will appear where,
 we store files that appear directly in the navigation bar
 in the root directory of the lesson.
-[The last episode]({{ site.github.url }}/03-organization/) describes these files.
+[The last episode]({{ page.root }}/03-organization/) describes these files.
 
 [github-importer]: https://import.github.com/
 [jekyll]: http://jekyllrb.com/

--- a/_episodes/03-organization.md
+++ b/_episodes/03-organization.md
@@ -38,11 +38,11 @@ Instead, each lesson's repository is self-contained.
 The diagram below shows how source files and directories are laid out,
 and how they are mapped to destination files and directories:
 
-![Source and Destination Files]({{ site.github.url }}/fig/file-mapping.svg)
+![Source and Destination Files]({{ page.root }}/fig/file-mapping.svg)
 
 > ## Collections
 >
-> As described [earlier]({{ site.github.url }}/02-tooling/#collections),
+> As described [earlier]({{ page.root }}/02-tooling/#collections),
 > files that appear as top-level items in the navigation menu are stored in the root directory.
 > Files that appear under the "extras" menu are stored in the `_extras` directory,
 > while lesson episodes are stored in the `_episodes` directory.

--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -28,7 +28,7 @@ each of which has:
 The diagram below shows the internal structure of a single episode file
 (click on the image to see a larger version):
 
-<a href="{{ site.github.url }}/fig/episode-format.png"><img src="{{ site.github.url }}/fig/episode-format-small.png" alt="Formatting Rules" /></a>
+<a href="{{ page.root }}/fig/episode-format.png"><img src="{{ page.root }}/fig/episode-format-small.png" alt="Formatting Rules" /></a>
 
 ## Locations and Names
 
@@ -47,7 +47,7 @@ in the published site.
 When referring to other episodes, use:
 
 {% raw %}
-    [link text]({{ site.github.url }}/dd-subject/)
+    [link text]({{ page.root }}/dd-subject/)
 {% endraw %}
 
 i.e., use the episode's directory path below the site root

--- a/_episodes/05-checking.md
+++ b/_episodes/05-checking.md
@@ -52,7 +52,7 @@ Run `make` on its own to get a full list of commands.
 
 In order to use Jekyll and/or the checking script,
 you may need to install it and some other software.
-The [setup instructions]({{ site.github.url }}/setup/) explain what you need and how to get it.
+The [setup instructions]({{ page.root }}/setup/) explain what you need and how to get it.
 
 ## Displaying Figures
 

--- a/_includes/all_figures.html
+++ b/_includes/all_figures.html
@@ -1,13 +1,13 @@
-<p><img alt="" src="{{ site.github.url }}/fig/using-github-import.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/using-github-import.png" /></p>
 <hr/>
-<p><img alt="Forking Repositories" src="{{ site.github.url }}/fig/forking.svg" /></p>
+<p><img alt="Forking Repositories" src="{{ page.root }}/fig/forking.svg" /></p>
 <hr/>
-<p><img alt="Repository Links" src="{{ site.github.url }}/fig/repository-links.svg" /></p>
+<p><img alt="Repository Links" src="{{ page.root }}/fig/repository-links.svg" /></p>
 <hr/>
-<p><img alt="Source and Destination Files" src="{{ site.github.url }}/fig/file-mapping.svg" /></p>
+<p><img alt="Source and Destination Files" src="{{ page.root }}/fig/file-mapping.svg" /></p>
 <hr/>
-<p><img alt="Formatting Rules" src="{{ site.github.url }}/fig/episode-format-small.png" /></p>
+<p><img alt="Formatting Rules" src="{{ page.root }}/fig/episode-format-small.png" /></p>
 <hr/>
-<p><img alt="" src="{{ site.github.url }}/fig/episode-format.png" /></p>
+<p><img alt="" src="{{ page.root }}/fig/episode-format.png" /></p>
 <hr/>
 <p><img alt="plot of chunk plot-example" src="../fig/rmd-plot-example-1.png" /></p>

--- a/_includes/all_keypoints.html
+++ b/_includes/all_keypoints.html
@@ -7,7 +7,7 @@
   {% unless episode.break %}
     <tr>
       <td class="col-md-3">
-        <a href="{{ site.github.url }}{{ episode.url }}">{{ episode.title }}</a>
+        <a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a>
       </td>
       <td class="col-md-9">
         <ul>

--- a/_includes/carpentries.html
+++ b/_includes/carpentries.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-2" align="center">
-    <a href="{{ site.swc_site }}"><img src="{{ site.github.url }}/assets/img/swc-icon-blue.svg" alt="Software Carpentry logo" /></a>
+    <a href="{{ site.swc_site }}"><img src="{{ page.root }}/assets/img/swc-icon-blue.svg" alt="Software Carpentry logo" /></a>
   </div>
   <div class="col-md-8">
     Since 1998,
@@ -14,7 +14,7 @@
 <br/>
 <div class="row">
   <div class="col-md-2" align="center">
-    <a href="{{ site.dc_site }}"><img src="{{ site.github.url }}/assets/img/dc-icon-black.svg" alt="Data Carpentry logo" /></a>
+    <a href="{{ site.dc_site }}"><img src="{{ page.root }}/assets/img/dc-icon-black.svg" alt="Data Carpentry logo" /></a>
   </div>
   <div class="col-md-8">
     <a href="{{ site.dc_site }}">Data Carpentry</a> develops and teaches workshops on the fundamental data skills needed to conduct research.

--- a/_includes/episode_title.html
+++ b/_includes/episode_title.html
@@ -20,24 +20,24 @@
   <div class="col-md-1">
     <h3>
       {% if prev_episode %}
-      <a href="{{ site.github.url }}{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left"></span></a>
-      {% elsif site.github.url %}
-      <a href="{{ site.github.url }}"><span class="glyphicon glyphicon-menu-up"></span></a>
+      <a href="{{ page.root }}{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left"></span></a>
+      {% elsif page.root %}
+      <a href="{{ page.root }}"><span class="glyphicon glyphicon-menu-up"></span></a>
       {% else %}
       <a href="/"><span class="glyphicon glyphicon-menu-up"></span></a>
       {% endif %}
     </h3>
   </div>
   <div class="col-md-10">
-    <h3 class="maintitle"><a href="{{ site.github.url }}/">{{ site.title }}</a></h3>
+    <h3 class="maintitle"><a href="{{ page.root }}/">{{ site.title }}</a></h3>
     <h1 class="maintitle">{{ page.title }}</h1>
   </div>
   <div class="col-md-1">
     <h3>
       {% if next_episode %}
-      <a href="{{ site.github.url }}{{ next_episode.url }}"><span class="glyphicon glyphicon-menu-right"></span></a>
-      {% elsif site.github.url %}
-      <a href="{{ site.github.url }}"><span class="glyphicon glyphicon-menu-up"></span></a>
+      <a href="{{ page.root }}{{ next_episode.url }}"><span class="glyphicon glyphicon-menu-right"></span></a>
+      {% elsif page.root %}
+      <a href="{{ page.root }}"><span class="glyphicon glyphicon-menu-up"></span></a>
       {% else %}
       <a href="/"><span class="glyphicon glyphicon-menu-up"></span></a>
       {% endif %}

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -1,3 +1,3 @@
-<script src="{{ site.github.url }}/assets/js/jquery.min.js"></script>
-<script src="{{ site.github.url }}/assets/js/bootstrap.min.js"></script>
-<script src="{{ site.github.url }}/assets/js/lesson.js"></script>
+<script src="{{ page.root }}/assets/js/jquery.min.js"></script>
+<script src="{{ page.root }}/assets/js/bootstrap.min.js"></script>
+<script src="{{ page.root }}/assets/js/lesson.js"></script>

--- a/_includes/main_title.html
+++ b/_includes/main_title.html
@@ -1,1 +1,1 @@
-<h1 class="maintitle"><a href="{{ site.github.url }}/">{{ site.title }}</a>{% if page.title %}: {{ page.title }}{% endif %}</h1>
+<h1 class="maintitle"><a href="{{ page.root }}/">{{ site.title }}</a>{% if page.title %}: {{ page.title }}{% endif %}</h1>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -11,41 +11,41 @@
       {% comment %} Select what logo to display. {% endcomment %}
       {% if page.carpentry == "swc" %}
       <a href="{{ site.swc_site }}" class="pull-left">
-        <img class="navbar-logo" src="{{ site.github.url }}/assets/img/swc-icon-blue.svg" alt="Software Carpentry logo" />
+        <img class="navbar-logo" src="{{ page.root }}/assets/img/swc-icon-blue.svg" alt="Software Carpentry logo" />
       </a>
       {% elsif page.carpentry == "dc" %}
       <a href="{{ site.dc_site }}" class="pull-left">
-        <img class="navbar-logo" src="{{ site.github.url }}/assets/img/dc-icon-black.svg" alt="Data Carpentry logo" />
+        <img class="navbar-logo" src="{{ page.root }}/assets/img/dc-icon-black.svg" alt="Data Carpentry logo" />
       </a>
       {% elsif site.carpentry == "swc" %}
       <a href="{{ site.swc_site }}" class="pull-left">
-        <img class="navbar-logo" src="{{ site.github.url }}/assets/img/swc-icon-blue.svg" alt="Software Carpentry logo" />
+        <img class="navbar-logo" src="{{ page.root }}/assets/img/swc-icon-blue.svg" alt="Software Carpentry logo" />
       </a>
       {% elsif site.carpentry == "dc" %}
       <a href="{{ site.dc_site }}" class="pull-left">
-        <img class="navbar-logo" src="{{ site.github.url }}/assets/img/dc-icon-black.svg" alt="Data Carpentry logo" />
+        <img class="navbar-logo" src="{{ page.root }}/assets/img/dc-icon-black.svg" alt="Data Carpentry logo" />
       </a>
       {% endif %}
 
       {% comment %} Always show link to home page. {% endcomment %}
-      <a class="navbar-brand" href="{{ site.github.url }}/">Home</a>
+      <a class="navbar-brand" href="{{ page.root }}/">Home</a>
 
     </div>
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
 
 	{% comment %} Always show code of conduct. {% endcomment %}
-        <li><a href="{{ site.github.url }}/conduct/">Code of Conduct</a></li>
+        <li><a href="{{ page.root }}/conduct/">Code of Conduct</a></li>
 
 	{% comment %} Show setup instructions, reference guide, and lesson episodes for lessons. {% endcomment %}
         {% if site.kind == "lesson" %}
-        <li><a href="{{ site.github.url }}/setup/">Setup</a></li>
-        <li><a href="{{ site.github.url }}/reference/">Reference</a></li>
+        <li><a href="{{ page.root }}/setup/">Setup</a></li>
+        <li><a href="{{ page.root }}/reference/">Reference</a></li>
         <li class="dropdown">
-          <a href="{{ site.github.url }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Episodes <span class="caret"></span></a>
+          <a href="{{ page.root }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Episodes <span class="caret"></span></a>
           <ul class="dropdown-menu">
             {% for episode in site.episodes %}
-            <li><a href="{{ site.github.url }}{{ episode.url }}">{{ episode.title }}</a></li>
+            <li><a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a></li>
             {% endfor %}
           </ul>
         </li>
@@ -54,17 +54,17 @@
 	{% comment %} Show extras for lessons or if this is the main workshop-template repo (where they contain documentation). {% endcomment %}
 	{% if site.kind == "lesson" or site.github.repository_name == "workshop-template" %}
         <li class="dropdown">
-          <a href="{{ site.github.url }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Extras <span class="caret"></span></a>
+          <a href="{{ page.root }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Extras <span class="caret"></span></a>
           <ul class="dropdown-menu">
             {% for extra in site.extras %}
-            <li><a href="{{ site.github.url }}{{ extra.url }}">{{ extra.title }}</a></li>
+            <li><a href="{{ page.root }}{{ extra.url }}">{{ extra.title }}</a></li>
             {% endfor %}
           </ul>
         </li>
 	{% endif %}
 
 	{% comment %} Always show license. {% endcomment %}
-        <li><a href="{{ site.github.url }}/license/">License</a></li>
+        <li><a href="{{ page.root }}/license/">License</a></li>
       </ul>
       <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">
         <div class="form-group">

--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -34,7 +34,7 @@
       {% if multiday %}<td class="col-md-1">{% if episode.start %}Day {{ day }}{% endif %}</td>{% endif %}
       <td class="col-md-1">{% if hours < 10 %}0{% endif %}{{ hours }}:{% if minutes < 10 %}0{% endif %}{{ minutes }}</td>
       <td class="col-md-3">
-        <a href="{{ site.github.url }}{{ episode.url }}">{{ episode.title }}</a>
+        <a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a>
       </td>
       <td class="col-md-7">
         {% if episode.break %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -8,9 +8,9 @@
     <meta http-equiv="last-modified" content="{{ site.time }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="search-domain" value="{{ site.github.url }}">
-    <link rel="stylesheet" type="text/css" href="{{ site.github.url }}/assets/css/bootstrap.css" />
-    <link rel="stylesheet" type="text/css" href="{{ site.github.url }}/assets/css/bootstrap-theme.css" />
-    <link rel="stylesheet" type="text/css" href="{{ site.github.url }}/assets/css/lesson.css" />
+    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap.css" />
+    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />
+    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/lesson.css" />
     {% if site.carpentry == "swc" %}
     <link rel="shortcut icon" type="image/x-icon" href="/favicon-swc.ico" />
     {% endif %}

--- a/_layouts/break.html
+++ b/_layouts/break.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+root: ..
 ---
 {% include episode_title.html %}
 {% include episode_break.html %}

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+root: ..
 ---
 {% include episode_title.html %}
 {% include episode_overview.html %}

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+root: .
 ---
 {% include main_title.html %}
 {{ content }}

--- a/_layouts/page_root.html
+++ b/_layouts/page_root.html
@@ -1,6 +1,6 @@
 ---
 layout: base
-root: ..
+root: .
 ---
 {% include main_title.html %}
 {{content}}

--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -1,5 +1,6 @@
 ---
 layout: page
+root: .
 title: "Reference"
 ---
 {% include all_keypoints.html %}

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -25,9 +25,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="last-modified" content="{{ site.time }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="{{ site.github.url }}/assets/css/bootstrap.css" />
-    <link rel="stylesheet" type="text/css" href="{{ site.github.url }}/assets/css/bootstrap-theme.css" />
-    <link rel="stylesheet" type="text/css" href="{{ site.github.url }}/assets/css/lesson.css" />
+    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap.css" />
+    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />
+    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/lesson.css" />
     {% if site.carpentry == "swc" %}
     <link rel="shortcut icon" type="image/x-icon" href="/favicon-swc.ico" />
     {% endif %}

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ This lesson shows how to use the
 For guidelines on how to help improve our lessons and this template,
 please see [the contribution guidelines][contributing];
 for guidelines on how to set up your machine to preview changes locally,
-please see [the setup instructions]({{ site.github.url }}/setup/).
+please see [the setup instructions]({{ page.root }}/setup/).
 
 > ## Prerequisites
 >

--- a/setup.md
+++ b/setup.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page_root
 title: Setup
 permalink: /setup/
 ---
@@ -63,7 +63,7 @@ lesson is `data-cleanup`.
 
 7.  At this point, you should have a page like this:
 
-    ![]({{ site.github.url }}/fig/using-github-import.png)
+    ![]({{ page.root }}/fig/using-github-import.png)
 
     You can now click "Begin Import".
     When the process is done,


### PR DESCRIPTION
1.  Make all intra-site references use `{{ page.root }}`.
2.  Define `root` in `_layouts/*`.
3.  Create a separate `_layouts/page_root.html` for `.md` files in the root directory because of the way Jekyll handles variable expansion.