### PR TITLE
Added lesson metadata and schema.org JSON-LD rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,19 @@ title: "Lesson Title"
 # Contact email address.
 email: lessons@software-carpentry.org
 
+#Metadata
+# Here you can add metadata to describe your lesson so that people and search engines can understand what it's about. Please try to use fields from the Schema.org CreativeWork type - https://schema.org/CreativeWork
+description:    "This is the template description. Keep me brief (2-3 sentences)"
+keywords:       GitHub, Forking, Collaborative                  # see: https://schema.org/keywords
+audience:       [PostDoc students, Early Career Researchers]    # see: https://schema.org/audience
+license:        "https://creativecommons.org/licenses/by/3.0/"  # see: schema.org/license
+author:         [Homer Simpson, Ned Flanders]                   # see: https://schema.org/author
+contributor:    [Barney Gumball, Dr Nick Riviera]               # see: https://schema.org/contributor
+timeRequired:   "1 hour"                                        # see: https://schema.org/timeRequired
+learningResourceType: "lesson plan"                             # see: https://schema.org/learningResourceType
+citation:       "How to cite a Training Material, John Smith et al, 2015" # see: https://schema.org/citation
+dateCreated:    2016-05-01        
+
 #------------------------------------------------------------
 # Generic settings (should not need to change).
 #------------------------------------------------------------

--- a/_includes/schema_org.html
+++ b/_includes/schema_org.html
@@ -1,0 +1,39 @@
+    <!-- Schema.org annotations in JSON-LD for a CreativeWork type.
+         Variables should be declared in the .md file 
+         For full list of available attributes see https://schema.org/CreativeWork -->
+    <script type="application/ld+json">
+    {
+       "@context": "http://schema.org/",
+       "@type": "creativeWork",
+       "genre": "trainingMaterial",
+       "name": "{{site.title}}",
+       "description": "{{site.description}}",
+       "keywords": "{{site.keywords}}",
+       "audience": [
+          {% for audience in site.audience %}{
+           "@type": "Audience",
+           "name": "{{audience}}"
+          }{% if forloop.last %}{%else%},{%endif%}
+          {% endfor %}
+       ],
+       "license": "{{site.licence}}",
+       "author": [
+         {% for author in site.author %}{
+           "@type": "Person",
+           "name": "{{author}}"
+          }{% if forloop.last %}{%else%},{%endif%}
+          {% endfor %}
+      ],
+       "contributor": [
+         {% for contributor in site.contributor %}{
+           "@type": "Person",
+           "name": "{{contributor}}"
+          }{% if forloop.last %}{%else%},{%endif%}
+          {% endfor %}
+      ],
+       "timeRequired": "{{site.timeRequired}}",
+       "learningResourceType": "{{site.learningResourceType}}",
+       "citation": "{{site.citation}}",
+       "dateCreated" : "{{site.dateCreated}}"
+    }
+    </script>

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -2,5 +2,6 @@
 layout: base
 ---
 {% include main_title.html %}
+{% include schema_org.html %}
 {{ content }}
 {% include syllabus.html %}


### PR DESCRIPTION
Hi,

I thought it might be a good idea to help the discoverability of training materials by having more metadata examples in the config, and by rendering the metadata into a [schema.org CreativeWork specification](schema.org/CreativeWork) using the JSON-LD representation.

If you think it's a good idea and accept the request, I can go about updating the existing Data Carpentry materials and format them similarly. 

Structuring metadata using Schema.org is very useful for SEO to get included in more Google SERPs; as well as for content integration platforms like [TeSS - The Life Science Training Portal](tess.elixir-uk.org). There's more about it on the working group page for [BioSchemas](bioschemas.org)

The variables declared in the _config.yml file are the attributes of the lesson correlated to the CreativeWork type. They are declared there and then rendered in JSON-LD in the schema_org.html partial. 

I've added a few example attributes but these variables could theoretically be the whole of http://schema.org/CreativeWork