### PR TITLE
Adding structure to instructor guides/notes

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -3,6 +3,15 @@ layout: page
 title: "Instructors' Guide"
 permalink: /guide/
 ---
-Discussion of the lesson aimed at instructors would normally go here,
-but since this is just an example,
-there isn't much to say.
+
+The instructor's guide should provide additional discussion useful to instructors, but not appropriate for inclusion in the main lessons. The following structure provides 
+
+## Lesson motivation and learning objectives
+
+These concepts should be highlighted in the main lesson material, but ideas for explaining these concepts further can be placed here.
+
+## Technical tips and tricks
+
+Setting up your environment
+
+## Common problems

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,10 +1,10 @@
 ---
 layout: page
-title: "Instructors' Guide"
+title: "Instructor Notes"
 permalink: /guide/
 ---
 
-The instructor's guide should provide additional discussion useful to instructors, 
+The instructor notes should provide additional discussion useful to instructors, 
 but not appropriate for inclusion in the main lessons. The following structure 
 provides a consistent way for instructors to both prepare for a workshop and 
 quickly find necessary information during a workshop.

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -4,14 +4,37 @@ title: "Instructors' Guide"
 permalink: /guide/
 ---
 
-The instructor's guide should provide additional discussion useful to instructors, but not appropriate for inclusion in the main lessons. The following structure provides 
+The instructor's guide should provide additional discussion useful to instructors, 
+but not appropriate for inclusion in the main lessons. The following structure 
+provides a consistent way for instructors to both prepare for a workshop and 
+quickly find necessary information during a workshop.
+
+Please remember not to overload on details, and to keep the comments here positive!
 
 ## Lesson motivation and learning objectives
 
-These concepts should be highlighted in the main lesson material, but ideas for explaining these concepts further can be placed here.
+These concepts should be highlighted in the main lesson material, but ideas for 
+explaining these concepts further can be placed here. 
+
+## Lesson design
+
+Most lessons contain more material than can be taught in a single workshop. 
+Describe a general narrative (with time estimates) for teaching either a half day 
+or full day with this lesson material. You may also choose to include multiple 
+options for lesson design, or what material can be skipped while teaching. 
+This section may also include recommendations for how this lesson fits into 
+the overall workshop.
 
 ## Technical tips and tricks
 
-Setting up your environment
+Provide information on setting up your environment for learners to view your 
+live coding (increasing text size, changing text color, etc), as well as 
+general recommendations for working with coding tools to best suit the 
+learning environment.
 
 ## Common problems
+
+This can include answers to common learner questions, as well as links to 
+resources (blog posts, stack overflow answers, etc) that may solve problems that 
+may occur during a workshop.
+


### PR DESCRIPTION
I've tried my hand at a draft of an instructor guide template. I've made the assumption that the guide should be a supplement to the lesson, rather than required reading (e.g, lessons should be stand-alone, for both instructor and learner use). I've tried to make this as generalizable to the whole set of DC/SWC lessons as possible (with the hope that DC adopts the new SWC template, but this certainly isn't required to use the language in this instructor guide template). This structure seems to be relatively easy to adopt into existing instructor guides, and would also help ease the way for new instructor guides to be developed.

This template is relatively simple, but I would be in favor of adding more structure to the section on lesson design and am open to any ideas!