### PR TITLE
Disambiguating "guides"

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Instructors' Guide"
+title: "Instructor Notes"
 permalink: /guide/
 ---
 Discussion of the lesson aimed at instructors would normally go here,


### PR DESCRIPTION
The mentoring subcommittee has requested that we change the name of the "Instructors' Guide" to "Instructor Notes," to avoid confusion with new roles called "guides" being developed, as well as make it easier to reference where instructors can go to find help. This PR only changes the title on the page (and corresponding changes in the content of `_episodes/03-organization.md`). 

It seems simplest to leave filenames as described now (e.g., `guide.md`), but I am interested in finding out if others believe this to be the best, most sustainable solution. 