### PR TITLE
Adding link to syllabus (episodes) from setup instructions

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Instructors' Guide"
+title: "Instructor Notes"
 permalink: /guide/
 ---
 Discussion of the lesson aimed at instructors would normally go here,

--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -3,7 +3,7 @@
   Days are displayed if at least one episode has 'start = true'.
 {% endcomment %}
 <div class="syllabus">
-  <h2>Schedule</h2>
+  <h2 id="schedule">Schedule</h2>
 
   {% assign day = 0 %}
   {% assign multiday = false %}

--- a/setup.md
+++ b/setup.md
@@ -104,7 +104,7 @@ lesson is `data-cleanup`.
     that cannot be put into the styles repository
     (because they would trigger repeated merge conflicts).
 
-12. Create and edit files as explained in the episodes of this lesson.
+12. Create and edit files as explained in [the episodes of this lesson]({{ page.root }}/#schedule).
 
 13. Preview the HTML pages for your lesson:
 


### PR DESCRIPTION
Replaces #56:

1. Adds ID attribute to syllabus.
2. Links to that instead of using `page.root`.