### PR TITLE
fix search box

### DIFF
--- a/_includes/episode_navbar.html
+++ b/_includes/episode_navbar.html
@@ -20,9 +20,9 @@
   <div class="col-md-1">
     <h3>
       {% if prev_episode %}
-      <a href="{{ page.root }}{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left"></span></a>
+      <a href="{{ page.root }}{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span><span class="sr-only">previous episode</span></a>
       {% else %}
-      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up"></span></a>
+      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
       {% endif %}
     </h3>
   </div>
@@ -35,9 +35,9 @@
   <div class="col-md-1">
     <h3>
       {% if next_episode %}
-      <a href="{{ page.root }}{{ next_episode.url }}"><span class="glyphicon glyphicon-menu-right"></span></a>
+      <a href="{{ page.root }}{{ next_episode.url }}"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><span class="sr-only">next episode</span></a>
       {% else %}
-      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up"></span></a>
+      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
       {% endif %}
     </h3>
   </div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -68,7 +68,7 @@
       </ul>
       <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">
         <div class="form-group">
-          <input type="text" id="google-search" placeholder="Search...">
+          <input type="text" id="google-search" placeholder="Search..." aria-label="Google site search">
         </div>
       </form>
     </div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="last-modified" content="{{ site.time }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="search-domain" value="{{ page.root }}">
+    <meta name="search-domain" value="{{ site.github.url }}">
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/lesson.css" />


### PR DESCRIPTION
fixes two search box issues:
1. adds `aria-label` to the `input` element to ensure accessibility. 
2. the google site search box is currently not working because the javascript looked for the repository url in a `meta` tag "search-domain" being filled by jekyll variable `page.root` which returns only `.`. With github pages the correct repository url can be called with the variable `site.github.url` (this will not work on your local version unless you have `github-pages` gem installed with a gemfile). This results in a correct google search that includes the operator like `site:http://swcarpentry.github.io/lesson-example`
