### PR TITLE
Fix display of double curlies using {% raw %}

### DIFF
--- a/_episodes/02-tooling.md
+++ b/_episodes/02-tooling.md
@@ -113,7 +113,7 @@ this page:
 ---
 name: Science
 ---
-Today we are going to study {{page.name}}.
+{% raw %}Today we are going to study {{page.name}}.{% endraw %}
 ~~~
 {: .source}
 


### PR DESCRIPTION
The example source block line currently renders as
    
    Today we are going to study .

This change causes it to display as

    Today we are going to study {{page.name}}.