### PR TITLE
Change target of setup link from .md to site page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ In brief:
 [github-pages]: https://help.github.com/articles/creating-project-pages-manually/
 [issues]: https://github.com/swcarpentry/lesson-example/issues
 [rendered]: https://swcarpentry.github.io/lesson-example/
-[setup]: ./setup.md
+[setup]: https://swcarpentry.github.io/lesson-example/setup/
 [styles-issues]: https://github.com/swcarpentry/styles/issues/
 [styles]: https://github.com/swcarpentry/styles/


### PR DESCRIPTION
The link worked fine, but directing people to the setup.md file instead of the rendered page means that other links don't work - such as item 12 in the setup page: https://github.com/swcarpentry/lesson-example/blob/gh-pages/setup.md