### PR TITLE
Towards a more fully offline capable rendering of a lesson

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: "Citation"
+permalink: /citation/
+---
+# Please cite as:
+
+Greg Wilson (ed.): "Software Carpentry: Lesson Example."  Version
+2016.06, June 2016, https://github.com/swcarpentry/lesson-example,
+10.5281/zenodo.58153.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+---
+layout: page
+title: "Contributing"
+permalink: /contributing/
+---
 # Contributing
 
 [Software Carpentry][swc-site] and [Data Carpentry][dc-site] are open source projects,
@@ -10,12 +15,12 @@ and reviews of proposed changes are all welcome.
 ## Contributor Agreement
 
 By contributing,
-you agree that we may redistribute your work under [our license](LICENSE.md).
+you agree that we may redistribute your work under [our license]({{ page.root }}/license/{{ site.index }}).
 In exchange,
 we will address your issues and/or assess your change proposal as promptly as we can,
 and help you become a member of our community.
 Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-agrees to abide by our [code of conduct](CONDUCT.md).
+agrees to abide by our [code of conduct]({{ page.root }}/conduct/{{ site.index }}).
 
 ## How to Contribute
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ title: "Lesson Title"
 # Contact email address.
 email: lessons@software-carpentry.org
 
+# Default web-server Index page (cab be blank)
+index: "index.html"
+
 #------------------------------------------------------------
 # Generic settings (should not need to change).
 #------------------------------------------------------------

--- a/_episodes/02-tooling.md
+++ b/_episodes/02-tooling.md
@@ -74,7 +74,7 @@ If authors want to write lessons in something else,
 such as [R Markdown][r-markdown],
 they must generate HTML or Markdown that [Jekyll][jekyll] can process
 and commit that to the repository.
-A [later episode]({{ page.root }}/04-formatting/) describes the Markdown we use.
+A [later episode]({{ page.root }}/04-formatting/{{ site.index }}) describes the Markdown we use.
 
 > ## Teaching Tools
 >
@@ -162,6 +162,6 @@ putting the extra files in `_extras` allows us to populate the "Extras" menu pul
 To clarify what will appear where,
 we store files that appear directly in the navigation bar
 in the root directory of the lesson.
-[The next episode]({{ page.root }}/03-organization/) describes these files.
+[The next episode]({{ page.root }}/03-organization/{{ site.index }}) describes these files.
 
 {% include links.md %}

--- a/_episodes/03-organization.md
+++ b/_episodes/03-organization.md
@@ -42,7 +42,7 @@ and how they are mapped to destination files and directories:
 
 > ## Collections
 >
-> As described [earlier]({{ page.root }}/02-tooling/#collections),
+> As described [earlier]({{ page.root }}/02-tooling/{{ site.index }}#collections),
 > files that appear as top-level items in the navigation menu are stored in the root directory.
 > Files that appear under the "extras" menu are stored in the `_extras` directory,
 > while lesson episodes are stored in the `_episodes` directory.

--- a/_episodes/05-checking.md
+++ b/_episodes/05-checking.md
@@ -52,7 +52,7 @@ Run `make` on its own to get a full list of commands.
 
 In order to use Jekyll and/or the checking script,
 you may need to install it and some other software.
-The [setup instructions]({{ page.root }}/setup/) explain what you need and how to get it.
+The [setup instructions]({{ page.root }}/setup/{{ site.index }}) explain what you need and how to get it.
 
 ## Displaying Figures
 

--- a/_includes/all_keypoints.html
+++ b/_includes/all_keypoints.html
@@ -7,7 +7,7 @@
   {% unless episode.break %}
     <tr>
       <td class="col-md-3">
-        <a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a>
+        <a href="{{ page.root }}{{ episode.url }}{{ site.index }}">{{ episode.title }}</a>
       </td>
       <td class="col-md-9">
         <ul>

--- a/_includes/episode_navbar.html
+++ b/_includes/episode_navbar.html
@@ -5,24 +5,24 @@
   <div class="col-md-1">
     <h3>
       {% if page.previous.url %}
-      <a href="{{ page.root }}{{ page.previous.url }}"><span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span><span class="sr-only">previous episode</span></a>
+      <a href="{{ page.root }}{{ page.previous.url }}{{ site.index }}"><span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span><span class="sr-only">previous episode</span></a>
       {% else %}
-      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
+      <a href="{{ page.root }}/{{ site.index }}"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
       {% endif %}
     </h3>
   </div>
   <div class="col-md-10">
     {% if include.episode_navbar_title %}
-    <h3 class="maintitle"><a href="{{ page.root }}/">{{ site.title }}</a></h3>
+    <h3 class="maintitle"><a href="{{ page.root }}/{{ site.index }}">{{ site.title }}</a></h3>
     <h1 class="maintitle">{{ page.title }}</h1>
     {% endif %}
   </div>
   <div class="col-md-1">
     <h3>
       {% if page.next.url %}
-      <a href="{{ page.root }}{{ page.next.url }}"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><span class="sr-only">next episode</span></a>
+      <a href="{{ page.root }}{{ page.next.url }}{{ site.index }}"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><span class="sr-only">next episode</span></a>
       {% else %}
-      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
+      <a href="{{ page.root }}/{{ site.index }}"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
       {% endif %}
     </h3>
   </div>

--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -19,7 +19,7 @@
       <h4>
 	<a href="{{ site.github.repository_url }}/">Source</a>
 	/
-	<a href="{{ site.github.repository_url }}/blob/gh-pages/CONTRIBUTING.md">Contributing</a>
+	<a href="{{ page.root }}/contributing/{{ site.index }}">Contributing</a>
 	/
 	<a href="{{ site.github.repository_url }}/blob/gh-pages/CITATION">Cite</a>
 	/

--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -21,7 +21,7 @@
 	/
 	<a href="{{ page.root }}/contributing/{{ site.index }}">Contributing</a>
 	/
-	<a href="{{ site.github.repository_url }}/blob/gh-pages/CITATION">Cite</a>
+	<a href="{{ page.root }}/citation/{{ site.index }}">Cite</a>
 	/
 	<a href="{{ site.contact }}">Contact</a>
       </h4>

--- a/_includes/main_title.html
+++ b/_includes/main_title.html
@@ -1,4 +1,4 @@
 {% comment %}
   Main title for lesson pages.
 {% endcomment %}
-<h1 class="maintitle"><a href="{{ page.root }}/">{{ site.title }}</a>{% if page.title %}: {{ page.title }}{% endif %}</h1>
+<h1 class="maintitle"><a href="{{ page.root }}/{{ site.index}}">{{ site.title }}</a>{% if page.title %}: {{ page.title }}{% endif %}</h1>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -39,24 +39,24 @@
       {% endif %}
 
       {% comment %} Always show link to home page. {% endcomment %}
-      <a class="navbar-brand" href="{{ page.root }}/">Home</a>
+      <a class="navbar-brand" href="{{ page.root }}/{{ site.index }}">Home</a>
 
     </div>
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
 
 	{% comment %} Always show code of conduct. {% endcomment %}
-        <li><a href="{{ page.root }}/conduct/">Code of Conduct</a></li>
+        <li><a href="{{ page.root }}/conduct/{{ site.index }}">Code of Conduct</a></li>
 
 	{% comment %} Show setup instructions, reference guide, and lesson episodes for lessons. {% endcomment %}
         {% if site.kind == "lesson" %}
-        <li><a href="{{ page.root }}/setup/">Setup</a></li>
-        <li><a href="{{ page.root }}/reference/">Reference</a></li>
+        <li><a href="{{ page.root }}/setup/{{ site.index }}">Setup</a></li>
+        <li><a href="{{ page.root }}/reference/{{ site.index }}">Reference</a></li>
         <li class="dropdown">
-          <a href="{{ page.root }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Episodes <span class="caret"></span></a>
+          <a href="{{ page.root }}/{{ site.index }}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Episodes <span class="caret"></span></a>
           <ul class="dropdown-menu">
             {% for episode in site.episodes %}
-            <li><a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a></li>
+            <li><a href="{{ page.root }}{{ episode.url }}{{ site.index }}">{{ episode.title }}</a></li>
             {% endfor %}
           </ul>
         </li>
@@ -65,17 +65,17 @@
 	{% comment %} Show extras for lessons or if this is the main workshop-template repo (where they contain documentation). {% endcomment %}
 	{% if site.kind == "lesson" or site.github.repository_name == "workshop-template" %}
         <li class="dropdown">
-          <a href="{{ page.root }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Extras <span class="caret"></span></a>
+          <a href="{{ page.root }}/{{ site.index }}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Extras <span class="caret"></span></a>
           <ul class="dropdown-menu">
             {% for extra in site.extras %}
-            <li><a href="{{ page.root }}{{ extra.url }}">{{ extra.title }}</a></li>
+            <li><a href="{{ page.root }}{{ extra.url }}{{ site.index }}">{{ extra.title }}</a></li>
             {% endfor %}
           </ul>
         </li>
 	{% endif %}
 
 	{% comment %} Always show license. {% endcomment %}
-        <li><a href="{{ page.root }}/license/">License</a></li>
+        <li><a href="{{ page.root }}/license/{{ site.index }}">License</a></li>
       </ul>
       <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">
         <div class="form-group">

--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -15,7 +15,7 @@
   <table class="table table-striped">
   <tr>
     <td class="col-md-1"></td>
-    <td class="col-md-3"><a href="{{ page.root }}/setup">Setup</a></td>
+    <td class="col-md-3"><a href="{{ page.root }}/setup/{{ site.index }}">Setup</a></td>
     <td class="col-md-7">Dowload files used on the lesson.</td>
   </tr>
   {% for episode in site.episodes %}
@@ -39,7 +39,7 @@
       {% if multiday %}<td class="col-md-1">{% if episode.start %}Day {{ day }}{% endif %}</td>{% endif %}
       <td class="col-md-1">{% if hours < 10 %}0{% endif %}{{ hours }}:{% if minutes < 10 %}0{% endif %}{{ minutes }}</td>
       <td class="col-md-3">
-        <a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a>
+        <a href="{{ page.root }}{{ episode.url }}{{ site.index }}">{{ episode.title }}</a>
       </td>
       <td class="col-md-7">
         {% if episode.break %}

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ This lesson shows how to use the
 For guidelines on how to help improve our lessons and this template,
 please see [the contribution guidelines][contributing];
 for guidelines on how to set up your machine to preview changes locally,
-please see [the setup instructions]({{ page.root }}/setup/).
+please see [the setup instructions]({{ page.root }}/setup/{{ site.index }}).
 
 > ## Prerequisites
 >

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ This lesson shows how to use the
 [Software Carpentry]({{ site.swc_site }}) and
 [Data Carpentry]({{ site.dc_site }}) lesson template.
 For guidelines on how to help improve our lessons and this template,
-please see [the contribution guidelines][contributing];
+please see [the contribution guidelines]({{ page.root }}/contributing/{{ site.index }});
 for guidelines on how to set up your machine to preview changes locally,
 please see [the setup instructions]({{ page.root }}/setup/{{ site.index }}).
 

--- a/setup.md
+++ b/setup.md
@@ -122,7 +122,7 @@ lesson is `data-cleanup`.
     that cannot be put into the styles repository
     (because they would trigger repeated merge conflicts).
 
-12. Create and edit files as explained in [the episodes of this lesson]({{ page.root }}/#schedule).
+12. Create and edit files as explained in [the episodes of this lesson]({{ page.root }}/{{ site.index }}#schedule).
 
 13. Preview the HTML pages for your lesson:
 


### PR DESCRIPTION
Basic ideas here are that:

1) Fully offline (no server required) browsing of a rendered _site directory's contents only 
    fails to work at present because of the lack of an "index.html" (or equivalent) at the end 
    of the bare URIs, which a webserver would usually, automatically, populate, eg Apache's  
   `DirectoryIndex` Directive, and so, for example,
```
    file:///path/to/_site/02-tooling/
```
   currently presents the offline user with that directory's contents, and so then they have to
   physically select  `index.html`, whereas, the ability to browse via a URI that a webserver
   would dynamically create, ie.,
```
    file:///path/to/_site/02-tooling/index.html
```
   would present the user with actual page they expect to see.

2) the lesson template's repos already contain both a `CONTRIBUTING.md` 
    and plain text `CITATION` file, but the links in the `lesson_footer.html` point
    back to the "blobs" within the remote source repo, so that content, albeit already
    there on disk in the cloned repo, is not available to the offline user browsing the 
    rendered _site.

The simple changes suggested here, which I believe require changes to both the main lesson 
example repo, and to the style repo, at the same time (submitted here as I am not sure 
as to how to go about that !) would thus:

1) add a methodology for defining a `{{ site.index }}` variable which would normally be 
    set to `index.html` but need not be. Similarly, the variable name I have chosen, `index`,
    need not be the name that SWC adopts should it want to provide this functionality.

2) make both the `Contributing` and `Cite` links in the footer point to rendered versions
   of the files already on disk in a cloned lesson 's local repo.

Here's hoping this is useful.