### PR TITLE
Add contributing link to the nav

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -76,6 +76,7 @@
 
 	{% comment %} Always show license. {% endcomment %}
         <li><a href="{{ page.root }}/license/">License</a></li>
+	<li><a href="{{ site.github.repository_url }}/blob/gh-pages/CONTRIBUTING.md">Contributing</a></li>
       </ul>
       <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">
         <div class="form-group">


### PR DESCRIPTION
# Motivation

@ErinBecker query me and @mkuzak about if the contributing instructors was easy to find
and I think that it need more visibility on the website.

# Screenshot

![screencapture-localhost-4000-1486226389406](https://cloud.githubusercontent.com/assets/1506457/22619971/bf94fb5c-eaf8-11e6-9f30-2cea1ef194f5.png)
