### PR TITLE
Make Creative License more visible

### DIFF
--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -13,6 +13,8 @@
 	{% elsif site.carpentry == "lc" %}
 	<a href="{{ site.lc_site }}">Library Carpentry</a>
 	{% endif %}
+	<br>
+	Licensed under Creative Commons Attribution.
       </h4>
     </div>
     <div class="col-md-6" align="right">


### PR DESCRIPTION
# Motivation

We want that readers know that our lessons are licensed under Creative Commons Attribution but they need to check the license page.

![screencapture-localhost-4000-1486226631487](https://cloud.githubusercontent.com/assets/1506457/22620013/2f6a10b0-eafa-11e6-8c3f-575c5fe77b25.png)

# Proposal

Add the license at the footnote.

# Proposal Screenshot

![screencapture-localhost-4000-1486226762709](https://cloud.githubusercontent.com/assets/1506457/22620012/24d89b9e-eafa-11e6-8891-9652458d1215.png)

# Question

Can we have "two" licenses? One for the website, since everything is text, and another for the GitHub repository, that actualy has code that need to be licensed such as the Makefile and under the `bin` folder?