### PR TITLE
Improve round corners on block input and output

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -32,6 +32,7 @@ $color-testimonial: #fc8dc1 !default;
   color: $color;
   border-left: solid 5px $color;
   margin-bottom: 0px;
+  border-radius: 4px 0 0 4px;
 }
 
 .error  { @include cdSetup($color-error); }
@@ -44,6 +45,18 @@ $color-testimonial: #fc8dc1 !default;
 .python { @include cdSetup($color-source); }
 .r      { @include cdSetup($color-source); }
 .sql    { @include cdSetup($color-source); }
+
+.error pre,
+.output pre,
+.source pre,
+.bash pre,
+.make pre,
+.matlab pre,
+.python pre,
+.r pre,
+.sql pre {
+  border-radius: 0 4px 4px 0;
+}
 
 //----------------------------------------
 // Specialized blockquote environments for learning objectives, callouts, etc.


### PR DESCRIPTION
# Description

There is a empty space between the left colour mark of block input/output and the actual code.

# Screenshot of Current Style

![screenshot_2017-02-18_17-50-19](https://cloud.githubusercontent.com/assets/1506457/23095522/fd79ea6c-f602-11e6-970c-24fe6d129e6c.png)

# Screenshot of Pull Request Style

![screenshot_2017-02-18_17-48-15](https://cloud.githubusercontent.com/assets/1506457/23095524/07f478c2-f603-11e6-97ed-3d6af9a24f1b.png)

# Additional notes

This is related with https://github.com/swcarpentry/styles/issues/95.

