### PR TITLE
add a callout about header IDs

### DIFF
--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -97,6 +97,17 @@ Authors should *not* use:
 *   sub-headings
 *   HTML layout (e.g., `div` elements).
 
+
+> ## Linking section IDs 
+>
+> In the HTML output each header of a section, code sample, exercise will be associated with an unique ID (the rules of 
+> the ID generation are given in kramdown [documentation](https://kramdown.gettalong.org/converter/html.html#auto-ids),
+> but it is easier to look for them directly in the page sources). 
+> These IDs can be used to easily link to the section by attaching the hash (`#`) followed by the ID to the page's URL 
+> (like [this](#linking-section-ids)). For example, the instructor might copy the link to 
+> the etherpad, so that the lesson opens in learners' web browser directly at the right spot. 
+{: .callout}
+
 ## Formatting Code
 
 Inline code fragments are formatted using back-quotes.


### PR DESCRIPTION
Kramdown will add id for all headers. These headers can be used to linking directly sections of the lesson (also exercises, call outs, etc.). This PR adds a call out explaining this feature.

closes https://github.com/swcarpentry/styles/issues/94 