### PR TITLE
Make easy to printing the whole lesson

### DIFF
--- a/_includes/episode_navbar.html
+++ b/_includes/episode_navbar.html
@@ -14,7 +14,6 @@
   <div class="col-md-10">
     {% if include.episode_navbar_title %}
     <h3 class="maintitle"><a href="{{ page.root }}/">{{ site.title }}</a></h3>
-    <h1 class="maintitle">{{ page.title }}</h1>
     {% endif %}
   </div>
   <div class="col-md-1">

--- a/_includes/episode_title.html
+++ b/_includes/episode_title.html
@@ -1,0 +1,9 @@
+<div class="row">
+  <div class="col-md-1">
+  </div>
+  <div class="col-md-10">
+    <h1 class="maintitle">{{ page.title }}</h1>
+  </div>
+  <div class="col-md-1">
+  </div>
+</div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -57,6 +57,8 @@
             {% for episode in site.episodes %}
             <li><a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a></li>
             {% endfor %}
+	    <li role="separator" class="divider"></li>
+            <li><a href="{{ page.root }}/aio/">All in one page</a></li>
           </ul>
         </li>
 	{% endif %}

--- a/_layouts/break.html
+++ b/_layouts/break.html
@@ -2,6 +2,9 @@
 layout: base
 ---
 {% include episode_navbar.html episode_navbar_title=true %}
+<article>
+{% include episode_title.html %}
 {% include episode_break.html %}
 {{content}}
+</article>
 {% include episode_navbar.html episode_navbar_title=false %}

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -2,7 +2,10 @@
 layout: base
 ---
 {% include episode_navbar.html episode_navbar_title=true %}
+<article>
+{% include episode_title.html %}
 {% include episode_overview.html %}
 {{content}}
 {% include episode_keypoints.html %}
+</article>
 {% include episode_navbar.html episode_navbar_title=false %}

--- a/aio.html
+++ b/aio.html
@@ -1,0 +1,36 @@
+---
+layout: page 
+permalink: /aio/
+---
+<script>
+  window.onload = function() {
+    var lesson_episodes = [
+    {% for episode in site.episodes %}
+    "{{ episode.url}}"{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ];
+    var xmlHttp = [];  /* Required since we are going to query every episode. */
+    for (i=0; i < lesson_episodes.length; i++) {
+      xmlHttp[i] = new XMLHttpRequest();
+      xmlHttp[i].episode = lesson_episodes[i];  /* To enable use this later. */
+      xmlHttp[i].onreadystatechange = function() {
+      if (this.readyState == 4 && this.status == 200) {
+        var article_here = document.getElementById(this.episode);
+        var parser = new DOMParser();
+        var htmlDoc = parser.parseFromString(this.responseText,"text/html");
+        var htmlDocArticle = htmlDoc.getElementsByTagName("article")[0];
+        article_here.innerHTML = htmlDocArticle.innerHTML;
+        }
+      }
+      episode_url = "{{ page.root }}" + lesson_episodes[i];
+      xmlHttp[i].open("GET", episode_url);
+      xmlHttp[i].send(null);
+    }
+  }
+</script>
+{% comment %}
+Create anchor for each one of the episodes.
+{% endcomment %}
+{% for episode in site.episodes %}
+<article id="{{ episode.url }}"></article>
+{% endfor %}


### PR DESCRIPTION
Related with #117.

# Description

After "failed" attempts to have a all in one version of the lessons in PDF, for print, and EPUB, for tablets and ereaders, due different Markdown flavours, our use of Javascript to hide part of the lesson (challenges, call out boxes, ...), LaTeX not handle boxes very easy and, the biggest limitation, users need to run the commands offline and commit the output so readers have access to it over GitHub Pages.

This pull request creates a page with Javascript that will query GitHub Pages for each episode and append the episode to the page so you will it. The final result is all the episodes at the same page and possibility to print it from the web browser, e.g. 
[lesson-example.pdf](https://github.com/swcarpentry/lesson-example/files/970368/lesson-example.pdf).

# Benefits

- Users only need to print one page.

# Drawbacks

None

# Implementation limitations

- If host impose limitation on number of views the page could fail to get all episodes.

# Related changes

Each individual episode content is wrapper into a `<article>`. **This is cover in this pull request and won't require manual changes from maintainers.**

# TODO

- [ ] User notification until all episodes are loaded properly.
- [ ] Show all hide parts so they are visible on the print version.