### PR TITLE
Edited setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -7,10 +7,10 @@ permalink: /setup/
 Our lesson template is kept in the `swcarpentry/styles` repository. The `styles` repository is carefully curated so that 
 changes made to it are easily mergable by downstream lessons. The `styles` repository contains various 
 bits that take Markdown files and render them as a lesson web page. For more information on how to develop 
-lessons and maintain them, see our [lesson-example](lesson-example). It will walk you through the basics of lesson 
+lessons and maintain them, see our [lesson-example](https://swcarpentry.github.io/lesson-example/). It will walk you through the basics of lesson 
 design and how to use GitHub, Markdown and Jekyll for lesson development. Follow the instructions below to make
 your own empty lesson in your own GitHub account. Once you've done that you can just write Markdown code and have 
-lesson web pages just like the [lesson-example](lesson-example) and all of our other lessons, but with your lesson content.
+lesson web pages just like the [lesson-example](https://swcarpentry.github.io/lesson-example/) and all of our other lessons, but with your lesson content.
 
 Requirements:
 * A GitHub account


### PR DESCRIPTION
Edited broken links to lesson-templates pages in setup.md

This pull request is for my instructor training checkout. It fixes this issue I opened: https://github.com/swcarpentry/lesson-example/issues/124