### PR TITLE
Enable syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -75,4 +75,4 @@ exclude:
   - bin
 
 # Turn off built-in syntax highlighting.
-highlighter: false
+highlighter: rouge

--- a/_config.yml
+++ b/_config.yml
@@ -74,5 +74,5 @@ exclude:
   - Makefile
   - bin
 
-# Turn off built-in syntax highlighting.
+# Turn on built-in syntax highlighting.
 highlighter: rouge

--- a/_episodes/02-tooling.md
+++ b/_episodes/02-tooling.md
@@ -128,7 +128,7 @@ is translated into:
 </body>
 </html>
 ~~~
-{: .source}
+{: .html}
 
 > ## Back in the Day...
 >

--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -137,7 +137,7 @@ which is rendered as:
 for thing in collection:
     do_something
 ~~~
-{: .source}
+{: .python}
 
 The class specified at the bottom using an opening curly brace and colon,
 the class identifier with a leading dot,

--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -166,12 +166,12 @@ specified language.
 Please use them where possible to indicate the type of source being displayed,
 and to make code easier to read.
 
-`.bash`: Bash shell commands:
+`.language-bash`: Bash shell commands:
 
 ~~~
 echo "Hello World"
 ~~~
-{: .bash}
+{: .language-bash}
 
 `.html`: HTML source:
 
@@ -184,43 +184,43 @@ echo "Hello World"
 ~~~
 {: .html}
 
-`.make`: Makefiles:
+`.language-make`: Makefiles:
 
 ~~~
 all:
     g++ main.cpp hello.cpp -o hello
 ~~~
-{: .make}
+{: .language-make}
 
-`.matlab`: MATLAB source:
+`.language-matlab`: MATLAB source:
 
 ~~~
 disp('Hello, world!')
 ~~~
-{: .matlab}
+{: .language-matlab}
 
-`.python`: Python source:
+`.language-python`: Python source:
 
 ~~~
 print("Hello World")
 ~~~
-{: .python}
+{: .language-python}
 
-`.r`: R source:
+`.language-r`: R source:
 
 ~~~
 cat("Hello World")
 ~~~
-{: .r}
+{: .language-r}
 
-`.sql`: SQL source:
+`.language-sql`: SQL source:
 
 ~~~
 CREATE PROCEDURE HelloWorld AS
 PRINT 'Hello, world!'
 RETURN (0)
 ~~~
-{: .sql}
+{: .language-sql}
 
 
 

--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -159,23 +159,70 @@ The [template]({{ site.template_repo }}) provides three styles for code blocks:
 ~~~
 {: .error}
 
-The following styles are all synonyms for `.source`;
-please use them where possible to indicate the type of source being displayed,
-in case we decide to adopt syntax highlighting at some point:
+### Syntax Highlighting
 
-*   `.bash`: Bash shell commands
-*   `.make`: Makefiles
-*   `.matlab`: MATLAB source
-*   `.python`: Python source
-*   `.r`: R source
-*   `.sql`: SQL source
+The following styles like `.source`, but include syntax highlighting for the
+specified language.
+Please use them where possible to indicate the type of source being displayed,
+and to make code easier to read.
 
-> ## Why No Syntax Highlighting?
->
-> We do not use syntax highlighting for code blocks
-> because some learners' systems won't do it,
-> or will do it differently than what they see on screen.
-{: .callout}
+`.bash`: Bash shell commands:
+
+~~~
+echo "Hello World"
+~~~
+{: .bash}
+
+`.html`: HTML source:
+
+~~~
+<html>
+<body>
+<em>Hello World</em>
+</body>
+</html>
+~~~
+{: .html}
+
+`.make`: Makefiles:
+
+~~~
+all:
+    g++ main.cpp hello.cpp -o hello
+~~~
+{: .make}
+
+`.matlab`: MATLAB source:
+
+~~~
+disp('Hello, world!')
+~~~
+{: .matlab}
+
+`.python`: Python source:
+
+~~~
+print("Hello World")
+~~~
+{: .python}
+
+`.r`: R source:
+
+~~~
+cat("Hello World")
+~~~
+{: .r}
+
+`.sql`: SQL source:
+
+~~~
+CREATE PROCEDURE HelloWorld AS
+PRINT 'Hello, world!'
+RETURN (0)
+~~~
+{: .sql}
+
+
 
 ## Special Blockquotes
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/lesson.css" />
+    <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/syntax.css" />
     {% if site.carpentry == "swc" %}
     <link rel="shortcut icon" type="image/x-icon" href="/favicon-swc.ico" />
     {% elsif site.carpentry == "dc" %}

--- a/assets/css/syntax.css
+++ b/assets/css/syntax.css
@@ -1,0 +1,69 @@
+.highlight .hll { background-color: #ffffcc }
+.highlight  { background: #f8f8f8; }
+.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: #666666 } /* Literal.Number */
+.highlight .s { color: #BA2121 } /* Literal.String */
+.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight .no { color: #880000 } /* Name.Constant */
+.highlight .nd { color: #AA22FF } /* Name.Decorator */
+.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #0000FF } /* Name.Function */
+.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #666666 } /* Literal.Number.Bin */
+.highlight .mf { color: #666666 } /* Literal.Number.Float */
+.highlight .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #0000FF } /* Name.Function.Magic */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .vm { color: #19177C } /* Name.Variable.Magic */
+.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -73,10 +73,12 @@ KNOWN_CODEBLOCKS = {
     'output',
     'source',
     'bash',
+    'html',
     'make',
     'matlab',
     'python',
     'r',
+    'shell',
     'sql'
 }
 

--- a/bin/lesson_initialize.py
+++ b/bin/lesson_initialize.py
@@ -243,7 +243,7 @@ exclude:
   - bin
 
 # Turn off built-in syntax highlighting.
-highlighter: false
+highlighter: rouge
 '''
 
 ROOT_INDEX_MD = '''\

--- a/bin/lesson_initialize.py
+++ b/bin/lesson_initialize.py
@@ -242,7 +242,7 @@ exclude:
   - Makefile
   - bin
 
-# Turn off built-in syntax highlighting.
+# Turn on built-in syntax highlighting.
 highlighter: rouge
 '''
 

--- a/setup.md
+++ b/setup.md
@@ -55,7 +55,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ git clone -b gh-pages https://github.com/timtomch/data-cleanup.git
     ~~~
-    {: .source}
+    {: .shell}
 
     Note that the URL for your lesson will have your username and chosen repository name.
 
@@ -64,7 +64,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ cd data-cleanup
     ~~~
-    {: .source}
+    {: .shell}
 
     Note that the name of your directory should be what you named your lesson 
     on the example this is `data-cleanup`.
@@ -75,7 +75,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ git remote add template https://github.com/swcarpentry/styles.git
     ~~~
-    {: .source}
+    {: .shell}
 
     This will allow you to pull in changes made to the template,
     such as improvements to our CSS style files.
@@ -87,7 +87,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ git checkout gh-pages
     ~~~
-    {: .source}
+    {: .shell}
 
 	This will ensure that you are using the most "stable" version of the
 	template repository. Since it's being actively maintained by the
@@ -107,7 +107,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ make serve
     ~~~
-    {: .source}
+    {: .shell}
 
 14. Commit your changes *and the HTML pages in the root directory of
     your lesson repository* and push to the `gh-pages` branch of your
@@ -119,7 +119,7 @@ new lesson is `data-cleanup`.
     $ git commit -m "Explanatory message"
     $ git push origin gh-pages
     ~~~
-    {: .source}
+    {: .shell}
 
 15. [Tell us][contact] where your lesson is so that we can add it to
     the appropriate index page(s).

--- a/setup.md
+++ b/setup.md
@@ -55,7 +55,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ git clone -b gh-pages https://github.com/timtomch/data-cleanup.git
     ~~~
-    {: .shell}
+    {: .bash}
 
     Note that the URL for your lesson will have your username and chosen repository name.
 
@@ -64,7 +64,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ cd data-cleanup
     ~~~
-    {: .shell}
+    {: .bash}
 
     Note that the name of your directory should be what you named your lesson 
     on the example this is `data-cleanup`.
@@ -75,7 +75,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ git remote add template https://github.com/swcarpentry/styles.git
     ~~~
-    {: .shell}
+    {: .bash}
 
     This will allow you to pull in changes made to the template,
     such as improvements to our CSS style files.
@@ -87,7 +87,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ git checkout gh-pages
     ~~~
-    {: .shell}
+    {: .bash}
 
 	This will ensure that you are using the most "stable" version of the
 	template repository. Since it's being actively maintained by the
@@ -107,7 +107,7 @@ new lesson is `data-cleanup`.
     ~~~
     $ make serve
     ~~~
-    {: .shell}
+    {: .bash}
 
 14. Commit your changes *and the HTML pages in the root directory of
     your lesson repository* and push to the `gh-pages` branch of your
@@ -119,7 +119,7 @@ new lesson is `data-cleanup`.
     $ git commit -m "Explanatory message"
     $ git push origin gh-pages
     ~~~
-    {: .shell}
+    {: .bash}
 
 15. [Tell us][contact] where your lesson is so that we can add it to
     the appropriate index page(s).


### PR DESCRIPTION
This is for https://github.com/swcarpentry/styles/issues/179

example at https://naught101.github.io/lesson-example/04-formatting/index.html

There is one outstanding issue, syntax highlighting only works on `.html` blocks when using the kramdown style code fencing with a specific language. e.g:

```
~~~
print("Hello World")
~~~
{: .language-python}
```

but this does not work:

```
~~~
print("Hello World")
~~~
{: .python}
```

Which is counter to the text description, and a little bit annoying.

On the other hand, markdown style highlighting does work:

~~~
```python
print("Hello World")
```
~~~

I think this format is easier to use and read, but that's probably just because I'm used to it. Also, I'm not sure if it will work on all systems (it does work on github pages, I think).

Not sure what the best solution is here. Perhaps there is a way to add e.g. `.python` as an alias to `.language-python`...