### PR TITLE
Fix link to setup page in index

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ This lesson shows how to use the
 For guidelines on how to help improve our lessons and this template,
 please see [the contribution guidelines][contributing];
 for guidelines on how to set up your machine to preview changes locally,
-please see [the setup instructions]({{ page.root }}/setup/).
+please see [the setup instructions]({{ page.root }}/setup.html).
 
 > ## Prerequisites
 >


### PR DESCRIPTION
The link to setup is broken. This pull request suggest to link to the existing setup page (`{{ page.root}}/setup.html`), but other options are 
 to change the permalink on Setup to `{{ site.url }}/setup/`
