### PR TITLE
update info on formative assessments

### DIFF
--- a/_episodes/01-design.md
+++ b/_episodes/01-design.md
@@ -72,9 +72,7 @@ In practice, the process often looks more like this:
 
 3.  Write a one- or two-line description of the formative assessments
     building up to those summative assessments.
-    These should be paced at roughly 15-minute intervals,
-    i.e.,
-    four per hour.
+    These should be used ideally every 5 minutes and at least every 10-15 minutes.
 
 4.  Get early feedback from peers,
     particularly on how realistic the time estimates are.
@@ -104,9 +102,6 @@ then formative assessments should take no more than 5 minutes.
 This means that formative assessments should be:
 
 *   multiple choice questions,
-*   Parsons Problems
-    (in which the learner is given the parts of the solution in scrambled order
-    and has to put them in the right order),
 *   debugging exercises
     (in which the learner is given a few lines of code that do the wrong thing
     and asked to find and fix the bug), or


### PR DESCRIPTION
This PR updates information on formative assessments to match current recommendations in the Instructor Training curriculum. 

From the [Importance of Practice](http://carpentries.github.io/instructor-training/02-practice-learning/) episode:

> > Instructors should use a formative assessment ideally every 5 minutes and at least every 10-15 minutes in order to make sure that the class is actually learning. Since the average attention span is usually only this long, formative assessments also help break up instructional time and re-focus attention.

I've also removed the reference to Parson's problems here, as they are no longer taught in Instructor Training.