### PR TITLE
remove episode length

### DIFF
--- a/_episodes/03-organization.md
+++ b/_episodes/03-organization.md
@@ -14,8 +14,8 @@ keypoints:
 - "The Makefile stores commonly-used commands."
 ---
 
-Each lesson is made up of *episodes* that are 10-30 minutes long
-(including time for both teaching and exercises).
+Each lesson is made up of *episodes*, which are focused on a particular topic and
+include time for both teaching and exercises.
 The episodes of this lesson explain the tools we use to create lessons
 and the formatting rules those lessons must follow.
 


### PR DESCRIPTION
Many episodes (both DC and SWC) are much longer than 20 minutes. For example:

Most [DC Ecology Python](http://www.datacarpentry.org/python-ecology-lesson/) episodes.
Most [DC Genomics Wrangling](http://www.datacarpentry.org/wrangling-genomics/) episodes.
Most [SWC Python Inflammation](http://swcarpentry.github.io/python-novice-inflammation/) episodes (if time was added for exercises, currently all exercises are set at 0 minutes).
Several [SWC R Gapminder](http://swcarpentry.github.io/r-novice-gapminder/) episodes.
Etc.

Previously, we had restricted episode length to ~15-20 minutes and had exercises between episodes to introduce appropriate breaks in lecturing. Now we intersperse exercises during the episode to introduce breaks. Thus episodes no longer need to be keep below 20 minutes.