### PR TITLE
fix link to setup instructions

### DIFF
--- a/_episodes/07-checking.md
+++ b/_episodes/07-checking.md
@@ -52,7 +52,7 @@ Run `make` on its own to get a full list of commands.
 
 In order to use Jekyll and/or the checking script,
 you may need to install it and some other software.
-The [setup instructions]({{ page.root }}/setup/) explain what you need and how to get it.
+The [setup instructions]({{ page.root }}/setup.html/) explain what you need and how to get it.
 
 ## Displaying Figures
 

--- a/_episodes/07-checking.md
+++ b/_episodes/07-checking.md
@@ -52,7 +52,7 @@ Run `make` on its own to get a full list of commands.
 
 In order to use Jekyll and/or the checking script,
 you may need to install it and some other software.
-The [setup instructions]({{ page.root }}/setup#optional-jekyll-setup-for-lesson-development/) explain what you need and how to get it.
+The [setup instructions]({{ page.root }}/setup/#optional-jekyll-setup-for-lesson-development) explain what you need and how to get it.
 
 ## Displaying Figures
 

--- a/_episodes/07-checking.md
+++ b/_episodes/07-checking.md
@@ -52,7 +52,7 @@ Run `make` on its own to get a full list of commands.
 
 In order to use Jekyll and/or the checking script,
 you may need to install it and some other software.
-The [setup instructions]({{ page.root }}/setup.html/) explain what you need and how to get it.
+The [setup instructions]({{ page.root }}/setup#optional-jekyll-setup-for-lesson-development/) explain what you need and how to get it.
 
 ## Displaying Figures
 


### PR DESCRIPTION
The link to setup page was going to a 404. I've updated it to point specifically at the part of the setup instructions that talk about installing jekyll and it's dependencies.