### PR TITLE
Fix class mismatch in formatting lesson

### DIFF
--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -137,7 +137,7 @@ which is rendered as:
 for thing in collection:
     do_something
 ~~~
-{: .language-python}
+{: .source}
 
 The class specified at the bottom using an opening curly brace and colon,
 the class identifier with a leading dot,


### PR DESCRIPTION
The 'input' (raw) block showed the `.source` class identifier, but the rendered output used `.language-python`.
