### PR TITLE
MacOS users cannot write to system Gems directory

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -173,6 +173,8 @@ you must install the software described below.
 
 3.  **[Jekyll][jekyll]**.
     You can install this by running `gem install jekyll`.
+    On a MacOS user does not have a permision to write to `/Library/Ruby/Gems/`.
+    Run `gem install jelyll --user-install` instead.
 
 4.  **R Packages**.
     We use [knitr][cran-knitr], [stringr][cran-stringr], and [checkpoint][cran-checkpoint]


### PR DESCRIPTION
This can be solved by installing with `sudo`, but the better approach is to
do user install.
Solution based on [Stack OVerflow solution](https://stackoverflow.com/a/38259128)

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
