### PR TITLE
Remove root and page from YAML header

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: "Contributor Code of Conduct"
 ---
 As contributors and maintainers of this project,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: "Licenses"
-root: .
 ---
 ## Instructional Material
 

--- a/_config.yml
+++ b/_config.yml
@@ -59,12 +59,20 @@ collections:
 # Set the default layout for things in the episodes collection.
 defaults:
   - values:
-      root: ..
+      root: .
+      layout: page
   - scope:
       path: ""
       type: episodes
     values:
       layout: episode
+      root: ..
+  - scope:
+      path: ""
+      type: extras
+    values:
+      root: ..
+      layout: page
 
 #------------------------------------------------------------
 # Jekyll Generic settings (should not need to change).

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: About
 ---
 

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Discussion
 ---
 

--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Figures
 ---
 <script>

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: "Instructor Notes"
 ---
 

--- a/aio.md
+++ b/aio.md
@@ -1,6 +1,4 @@
 ---
-layout: page 
-root: .
 ---
 <script>
   window.onload = function() {

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: lesson
-root: .
+root: .  # Is the only page that don't follow the partner /:path/index.html
 permalink: index.html  # Is the only page that don't follow the partner /:path/index.html
 ---
 

--- a/setup.md
+++ b/setup.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Setup
-root: .
 ---
 
 Our lesson template is kept in the [`swcarpentry/styles` repository][styles]. The `styles` repository is carefully curated so that


### PR DESCRIPTION
Because we can use `_config.yml`.

Related with swcarpentry/lesson-example#205